### PR TITLE
Fix recyclerview fill all items

### DIFF
--- a/codeview/src/main/java/io/github/kbiakov/codeview/views/BidirectionalScrollView.kt
+++ b/codeview/src/main/java/io/github/kbiakov/codeview/views/BidirectionalScrollView.kt
@@ -45,6 +45,9 @@ class BidirectionalScrollView : HorizontalScrollView {
     }
 
     override fun onTouchEvent(ev: MotionEvent?): Boolean {
+        // call recyclerview's and its onTouchEvent here
+        // to support cross-direction scrolling like 'scroll' method does before. (eg: 45° left top to right down)
+
         // first, force child recyclerview handles vertical scrolling.
         codeContentRv.onTouchEvent(ev)
         // then handle horizontal scrolling here.

--- a/codeview/src/main/java/io/github/kbiakov/codeview/views/BidirectionalScrollView.kt
+++ b/codeview/src/main/java/io/github/kbiakov/codeview/views/BidirectionalScrollView.kt
@@ -1,12 +1,15 @@
 package io.github.kbiakov.codeview.views
 
 import android.content.Context
+import android.support.v7.widget.LinearLayoutManager
+import android.support.v7.widget.RecyclerView
 import android.util.AttributeSet
 import android.view.MotionEvent
 import android.view.View
+import android.view.View.MeasureSpec
 import android.view.View.MeasureSpec.makeMeasureSpec
 import android.widget.HorizontalScrollView
-import io.github.kbiakov.codeview.dpToPx
+import io.github.kbiakov.codeview.R
 
 /**
  * @class BidirectionalScrollView
@@ -18,67 +21,61 @@ import io.github.kbiakov.codeview.dpToPx
  */
 class BidirectionalScrollView : HorizontalScrollView {
 
-    private var currentX = 0
-    private var currentY = 0
-    private var isMoved = false
-
     constructor(context: Context) : super(context)
     constructor(context: Context, attrs: AttributeSet) : super(context, attrs)
     constructor(context: Context, attrs: AttributeSet, defStyleAttr: Int) : super(context, attrs, defStyleAttr)
 
-    override fun dispatchTouchEvent(event: MotionEvent): Boolean {
-        when (event.action) {
-            MotionEvent.ACTION_DOWN -> {
-                currentX = event.rawX.toInt()
-                currentY = event.rawY.toInt()
-                return super.dispatchTouchEvent(event)
-            }
-            MotionEvent.ACTION_MOVE -> {
-                val deltaX = Math.abs(currentX - event.rawX)
-                val deltaY = Math.abs(currentY - event.rawY)
-                scroll(event)
+    private lateinit var codeContentRv: RecyclerView
 
-                val movedOnDistance = dpToPx(context, 2)
-                if (deltaX > movedOnDistance || deltaY > movedOnDistance) {
-                    isMoved = true
-                }
-            }
-            MotionEvent.ACTION_UP -> {
-                if (!isMoved) {
-                    return super.dispatchTouchEvent(event)
-                }
-                isMoved = false
-            }
-            MotionEvent.ACTION_CANCEL -> {
-                isMoved = false
-            }
-        }
+    override fun onAttachedToWindow() {
+        super.onAttachedToWindow()
+        codeContentRv = findViewById(R.id.rv_code_content)
+    }
+
+    override fun dispatchTouchEvent(event: MotionEvent): Boolean {
+        super.dispatchTouchEvent(event)
+        // consumed by this ViewGroup.
         return true
     }
 
-    private fun scroll(event: MotionEvent) {
-        val x2 = event.rawX.toInt()
-        val y2 = event.rawY.toInt()
-        val posX = currentX - x2
-        val posY = currentY - y2
-        scrollBy(posX, posY)
+    override fun onInterceptTouchEvent(ev: MotionEvent?): Boolean {
+        super.onInterceptTouchEvent(ev)
+        // let touch event be stolen(intercepted) here.
+        return true
+    }
 
-        currentX = x2
-        currentY = y2
+    override fun onTouchEvent(ev: MotionEvent?): Boolean {
+        // first, force child recyclerview handles vertical scrolling.
+        codeContentRv.onTouchEvent(ev)
+        // then handle horizontal scrolling here.
+        super.onTouchEvent(ev)
+        // finally mark this event is handled.
+        return true
     }
 
     override fun measureChild(child: View, parentWidthMeasureSpec: Int, parentHeightMeasureSpec: Int) {
         val zeroMeasureSpec = makeMeasureSpec(0)
-        child.measure(zeroMeasureSpec, zeroMeasureSpec)
+        // let the child RecyclerView know the actual height.
+        child.measure(zeroMeasureSpec, parentHeightMeasureSpec)
     }
 
     override fun measureChildWithMargins(
-            child: View,
-            parentWidthMeasureSpec: Int, widthUsed: Int,
-            parentHeightMeasureSpec: Int, heightUsed: Int
+        child: View,
+        parentWidthMeasureSpec: Int, widthUsed: Int,
+        parentHeightMeasureSpec: Int, heightUsed: Int
     ) = with(child.layoutParams as MarginLayoutParams) {
+
         val widthMeasureSpec = makeMeasureSpec(leftMargin + rightMargin, MeasureSpec.UNSPECIFIED)
-        val heightMeasureSpec = makeMeasureSpec(topMargin + bottomMargin, MeasureSpec.UNSPECIFIED)
+        /**
+         * Let the child RecyclerView know the actual height again.
+         * Because [RecyclerView.LayoutManager.mHeightMode] is determined by MeasureSpec mode in [RecyclerView.onMeasure].
+         * If gives a [MeasureSpec.UNSPECIFIED] here, mHeightMode will be 0 and [LinearLayoutManager.LayoutState.mInfinite] will be true.
+         * It will cause [LinearLayoutManager.fill] iterates all items in adapter instead of remaining space allowed,
+         * which blocks main thread for a long time if there are many items in adapter,
+         */
+        val heightMode = MeasureSpec.getMode(parentHeightMeasureSpec)
+        val parentHeight = MeasureSpec.getSize(parentHeightMeasureSpec)
+        val heightMeasureSpec = makeMeasureSpec(parentHeight + topMargin + bottomMargin, heightMode)
         child.measure(widthMeasureSpec, heightMeasureSpec)
     }
 

--- a/codeview/src/main/java/io/github/kbiakov/codeview/views/BidirectionalScrollView.kt
+++ b/codeview/src/main/java/io/github/kbiakov/codeview/views/BidirectionalScrollView.kt
@@ -6,7 +6,6 @@ import android.support.v7.widget.RecyclerView
 import android.util.AttributeSet
 import android.view.MotionEvent
 import android.view.View
-import android.view.View.MeasureSpec
 import android.view.View.MeasureSpec.makeMeasureSpec
 import android.widget.HorizontalScrollView
 import io.github.kbiakov.codeview.R
@@ -69,6 +68,7 @@ class BidirectionalScrollView : HorizontalScrollView {
     ) = with(child.layoutParams as MarginLayoutParams) {
 
         val widthMeasureSpec = makeMeasureSpec(leftMargin + rightMargin, MeasureSpec.UNSPECIFIED)
+
         /**
          * Let the child RecyclerView know the actual height again.
          * Because [RecyclerView.LayoutManager.mHeightMode] is determined by MeasureSpec mode in [RecyclerView.onMeasure].

--- a/codeview/src/main/res/layout/layout_code_view.xml
+++ b/codeview/src/main/res/layout/layout_code_view.xml
@@ -5,16 +5,17 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content">
 
+    <!-- Just let the root RelativeLayout determine the height of the code viewport.-->
     <io.github.kbiakov.codeview.views.BidirectionalScrollView
         android:id="@+id/v_scroll"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        android:layout_height="match_parent"
         android:fillViewport="true">
 
         <android.support.v7.widget.RecyclerView
             android:id="@+id/rv_code_content"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
+            android:layout_height="match_parent"
             tools:listitem="@layout/item_code_line"/>
 
     </io.github.kbiakov.codeview.views.BidirectionalScrollView>


### PR DESCRIPTION
Pass MeasureSpec.UNSPECIFIED mode to child RecyclerView for providing a virtual 'infinite' vertical space will cause LinearLayoutManager try to 'fill' remaining space using ALL items in adapter, which may let main thread running measures for a long time. Just provide an 'infinite' horizontal space for long-line code is enough, then layout manager and touch event handle methods in RecyclerView can handle vertical scrolling perfectly. Can also fix missing velocity in code panel.

Flame chart showing such issue:
![image](https://user-images.githubusercontent.com/10548832/117096478-c0233100-ad9b-11eb-8082-1f8a653a065d.png)

Screen records (Xiaomi MIX2S, Qualcomm 845, should not appear a loading holder for just a 370+ lines log file.):

![out](https://user-images.githubusercontent.com/10548832/117096970-147ae080-ad9d-11eb-9a13-c3d8e18f1a21.gif)
